### PR TITLE
Fixing cloning behaviour

### DIFF
--- a/src/helpers/__tests__/cloneChildren-test.js
+++ b/src/helpers/__tests__/cloneChildren-test.js
@@ -44,7 +44,7 @@ describe('cloneChildren', () => {
         });
     });
 
-    it('clones Errrors and populates errors fields', () => {
+    it('clones Errors and populates errors fields', () => {
         const rule = createErrorsRule({
             errors: ['Some bad error'],
             fieldErrors: {
@@ -53,7 +53,7 @@ describe('cloneChildren', () => {
         });
 
         const children = [<Errors />];
-        const errorsClone = cloneChildren([rule], children)[0];
+        const errorsClone = cloneChildren([rule], children);
 
         expect(errorsClone.props.fieldErrors.fieldname).toBe('Some bad error');
         expect(errorsClone.props.errors[0]).toBe('Some bad error');
@@ -61,9 +61,9 @@ describe('cloneChildren', () => {
 
     it('clones leaf nodes as expected', () => {
         const children = [<p>hello</p>];
-        const pTagClone = cloneChildren([], children)[0];
+        const pTagClone = cloneChildren([], children);
 
-        expect(pTagClone.props.children[0]).toBe('hello');
+        expect(pTagClone.props.children).toBe('hello');
     });
 
     it('warns when children share same name', () => {

--- a/src/helpers/__tests__/cloneChildren-test.js
+++ b/src/helpers/__tests__/cloneChildren-test.js
@@ -92,4 +92,13 @@ describe('cloneChildren', () => {
         expect(warning).not.toBeCalledWith(false, 'Duplicate name "color" found. Duplicate fields will be ignored');
         expect(warning).not.toBeCalledWith(false, 'Duplicate name "shape" found. Duplicate fields will be ignored');
     });
+
+    it('returns a single child (not an array of one) when cloning a single child', () => {
+        const createFormableRule = require('../cloneChildren').createFormableRule;
+        const rule = createFormableRule({})
+        const children = <p>some sub element</p>;
+        const clone = cloneChildren([rule], children);
+
+        expect(React.Children.only(clone)).toBe(clone);
+    })
 });

--- a/src/helpers/cloneChildren.js
+++ b/src/helpers/cloneChildren.js
@@ -102,10 +102,11 @@ export function createFormableRule(
 export default function cloneChildren(rules, children, childNames = []) {
     if (children) {
         const cloneRules = [leafRule, ...rules, createRecursiveRule(rules)];
-
-        return React.Children.map(children, (child) => {
+        const clones = React.Children.map(children, (child) => {
             // find first rule that passes and use it to clone
             return cloneRules.find(rule => rule.predicate(child)).clone(child, childNames);
         });
+
+        return React.Children.count(clones) == 1 ? clones[0] : clones;
     }
 }


### PR DESCRIPTION
When cloning single elements, don't bother using arrays.

Allows us to use `React.children.only` in our cloned formable components without problems.
