### PR TITLE
Refactor serialize

### DIFF
--- a/example/src/controllers/api/subsections/form.js
+++ b/example/src/controllers/api/subsections/form.js
@@ -7,7 +7,8 @@ The top level \`Form\` component is what serializes your data.
 | onSubmit | function(form) | undefined | A callback which will be called whenever the form is submitted. Receives the serialized form object. |
 | showErrorsOnSubmit | boolean | true | A boolean to decide if errors should be shown on submit. |
 | showErrorsOnChange | boolean(form) | false | A boolean to decide if errors should be shown on change. |
-| validators | array[function(form)] | [] | An array of validators to run over the form. Useful to capture business logic. Not automatically bound to the form. |
+| validators | array[function] | [] | An array of validators to run over the form. Useful to capture business logic. |
+| addValidationErrors | boolean | false | Add \`fieldErrors\` to your validators. This allows you to reference other components field errors within your validation methods as its last parameter. |
 
 
 There are a handful of methods on the \`Form\` component which are useful. To access these, attach a \`ref\` to the \`Form\` and call them via \`this.refs.refName.methodName();\`.

--- a/example/src/controllers/api/subsections/validators/validators.js
+++ b/example/src/controllers/api/subsections/validators/validators.js
@@ -32,6 +32,15 @@ A validator is supplied via the property \`validators\` which expects an array o
        ]} />
 \`\`\`
 
+These functions have the following call signatures. Note, \`fieldErrors\` will only be present if \`addValidationErrors\` is true on the \`Form\` component. \`fieldErrors\` and \`fieldValues\` are the values you recive when serialize the form.
+
+| Component | Params | Description |
+| :----- | :----- | :---------- |
+| Inputs | value: Number String Boolean, fieldValues: Object, fieldErrors? : Object | Here the value is the input's value |
+| Fieldset | value: Object, fieldValues: Object, fieldErrors?: Object | A fieldset recives a value of all its children in object form |
+| Fieldlist | value: Array, fieldValues: Object, fieldErrors?: Object | A fieldlist recives a value of a list of its children |
+| Form | value: Object, fieldValues: Object, fieldErrors?: Object | Value here is all the values within the form |
+
 Returning a message from a validator indicates a fail. Returning nothing indicates a pass.
 
 \`react-formable\` supplies some common use-case stock validators which you can import and use list below.

--- a/example/src/controllers/guides/subsections/adding-validation/description.md
+++ b/example/src/controllers/guides/subsections/adding-validation/description.md
@@ -6,7 +6,7 @@ Each validator takes the following three parameters:
 
 - `value`: The current value of the object. For inputs, it will be the value of the inputs. For `Form`s, `Fieldset`s, and `Fieldlist`s it will be an object or array of all the fields underneath it.
 - `fieldValues`: All the `fieldValues` for the form.
-- `fieldErrors`: All the `fieldErrors` for the form.
+- `fieldErrors?`: All the `fieldErrors` for the form. This will only be present if `addValidationErrors` is set to `true` on the parent `Form`.
 
 **NB:** `fieldValues` and `fieldErrors` in our validators params are the same values we receive in `onSubmit` and `onSuccess`.
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "marked": "^0.3.5",
     "react": "^0.14.0",
     "react-addons-test-utils": "^0.14.3",
-    "react-component-gulp-tasks": "^0.7.7",
+    "react-component-gulp-tasks": "github:kaw2k/react-component-gulp-tasks",
     "react-dom": "^0.14.0",
     "react-router": "^1.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "marked": "^0.3.5",
     "react": "^0.14.0",
     "react-addons-test-utils": "^0.14.3",
-    "react-component-gulp-tasks": "github:kaw2k/react-component-gulp-tasks",
+    "react-component-gulp-tasks": "react-component-gulp-tasks",
     "react-dom": "^0.14.0",
     "react-router": "^1.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "marked": "^0.3.5",
     "react": "^0.14.0",
     "react-addons-test-utils": "^0.14.3",
-    "react-component-gulp-tasks": "react-component-gulp-tasks",
+    "react-component-gulp-tasks": "^0.7.7",
     "react-dom": "^0.14.0",
     "react-router": "^1.0.2"
   },

--- a/src/__tests__/fieldlist-test.js
+++ b/src/__tests__/fieldlist-test.js
@@ -78,7 +78,7 @@ describe('Fieldlist', () => {
                             <label> Pet Name: <Input name="name" type="text"
                                 validators={[required(`name${i} is required`)]} /> </label>
                         </div>
-                    })};
+                    })}
                 </Fieldlist>
             </Form>
         );

--- a/src/__tests__/fieldset-test.js
+++ b/src/__tests__/fieldset-test.js
@@ -35,7 +35,7 @@ describe('Fieldset', () => {
         const inputs = fieldset.getInputs();
 
         expect(inputs.ref).toEqual(fieldset);
-        expect(inputs.refs['name'].ref.getValue()).toBe('george');
-        expect(inputs.refs['type'].ref.getValue()).toBe('dog');
+        expect(inputs.refs['name'].value.getValue()).toBe('george');
+        expect(inputs.refs['type'].value.getValue()).toBe('dog');
     });
 });

--- a/src/fieldlist.js
+++ b/src/fieldlist.js
@@ -17,7 +17,7 @@ export default React.createClass({
         return {
             ref: this,
             refs: values(this.refs.fieldset.getInputs().refs)
-                    .filter(node => node.refs && values(node.refs).length)
+                    .filter(node => node.children && values(node.children).length)
         };
     },
 

--- a/src/fieldset.js
+++ b/src/fieldset.js
@@ -20,7 +20,7 @@ export default React.createClass({
             refs: values(this.refs || {})
                     .filter(ref => (ref.getInputs || ref.getValue))
                     .map(ref => ref.getInputs ? ref.getInputs() : { ref })
-                    .map(tree)
+                    .map(x => tree(x.ref, x.refs))
                     .reduce((memo, node) => {
                         memo[node.ref.props.name] = node;
                         return memo;

--- a/src/fieldset.js
+++ b/src/fieldset.js
@@ -2,6 +2,7 @@ import React, { PropTypes } from 'react';
 import cloneChildren, { createErrorsRule, createFormableRule } from './helpers/cloneChildren';
 import values from './helpers/values';
 import warning from 'warning';
+import tree from './helpers/tree';
 
 export default React.createClass({
     displayName: 'Fieldset',
@@ -19,6 +20,7 @@ export default React.createClass({
             refs: values(this.refs || {})
                     .filter(ref => (ref.getInputs || ref.getValue))
                     .map(ref => ref.getInputs ? ref.getInputs() : { ref })
+                    .map(tree)
                     .reduce((memo, node) => {
                         memo[node.ref.props.name] = node;
                         return memo;

--- a/src/fieldset.js
+++ b/src/fieldset.js
@@ -22,7 +22,7 @@ export default React.createClass({
                     .map(ref => ref.getInputs ? ref.getInputs() : { ref })
                     .map(x => tree(x.ref, x.refs))
                     .reduce((memo, node) => {
-                        memo[node.ref.props.name] = node;
+                        memo[node.value.props.name] = node;
                         return memo;
                     }, {})
         };

--- a/src/form.js
+++ b/src/form.js
@@ -29,7 +29,7 @@ export default React.createClass({
     displayName: 'Form',
 
     propTypes: {
-        circular: PropTypes.bool,
+        addValidationFieldErrors: PropTypes.bool,
 
         // Handlers for your form callbacks. These will be called with the
         // current serialization of the form
@@ -118,7 +118,7 @@ export default React.createClass({
         // explicit dependencies. We fake dependencies by making
         // an eventually stable tree.
         } while(
-            this.props.circular &&
+            this.props.addValidationFieldErrors &&
             iteration < refLength &&
             JSON.stringify(form) !== JSON.stringify(oldForm)
         );

--- a/src/form.js
+++ b/src/form.js
@@ -102,7 +102,9 @@ export default React.createClass({
                     const fieldValues = form.fieldValues;
                     const fieldErrors = this.props.addValidationFieldErrors ? oldForm.fieldErrors : null;
 
-                    return validators.map(fn => fn(value, fieldValues, fieldErrors));
+                    return validators
+                            .map(fn => fn(value, fieldValues, fieldErrors))
+                            .filter(identity);
                 });
 
             form.fieldErrors = formTreeErrors.extract()

--- a/src/form.js
+++ b/src/form.js
@@ -1,8 +1,9 @@
 import React, { PropTypes } from 'react';
 import uniq from './helpers/uniq';
 import values from './helpers/values';
-import identity from './helpers/identity';
 import cloneChildren, { createErrorsRule, createFormableRule } from './helpers/cloneChildren';
+import tree from './helpers/tree';
+import identity from './helpers/identity';
 
 export const getBlankForm =function getBlankForm() {
     return {
@@ -13,139 +14,16 @@ export const getBlankForm =function getBlankForm() {
     };
 };
 
-export const deNestErrors = function deNestErrors(errors) {
-    // Our base case, strings or nulls
-    if (!errors || typeof errors === 'string')
-        return errors;
+const treeValue = function treeValue(tree) {
+    return tree.map(ref => ref.getValue && ref.getValue()).extract();
+};
 
-    // Arrays are objects, so we have to check arrays first
-    // Iterate over each value in our array and denest it. Combine all These
-    // results into one array and return it
-    if (errors.constructor === Array)
-        return [].concat.apply([], errors.map(val => deNestErrors(val)));
+const getValidators = function getValidators(ref) {
+    const propValidators = ref && ref.props && ref.props.validators || [];
+    const refValidators = ref && ref.validators || [];
 
-    // Iterate over each value within our object and denest them
-    if (typeof errors === 'object')
-        return deNestErrors(values(errors));
-
-    // Fallback in case something real weird happens
-    return errors;
+    return [].concat(propValidators, refValidators);
 }
-
-const nodeToValues = function nodeToValues(node) {
-    // Whoops, bad things happening
-    if (!node) return node;
-
-    // We are either starting off or not at a leaf yet. Regardless traverse
-    // the path downwards until we hit a leaf
-    if (node.constructor === Array) {
-        return node.reduce((memo, currentNode) => {
-            memo[currentNode.ref.props.name] = nodeToValues(currentNode);
-            return memo;
-        }, {});
-    }
-
-    if (node.refs && node.refs.constructor === Array) {
-        return node.refs.map(r => nodeToValues(r));
-    }
-
-    if (node.refs && typeof node.refs === 'object') {
-        return values(node.refs).reduce((memo, currentNode) => {
-            memo[currentNode.ref.props.name] = nodeToValues(currentNode);
-            return memo;
-        }, {});
-    }
-
-    // We are at a leaf, give our value back
-    return node.ref.getValue();
-}
-
-// node: The current node we are looking at { ref: Object, refs?: Object|Array }
-// treeValues: The current value / object in the tree
-// treeErrors: The current array of errors / object of errors in the tree
-// form: The overall form
-// returns { fieldErrors: Object, errors: array }
-const toErrors = function toErrors(node, treeValues, treeErrors={}, form) {
-    // Something bad is happening here
-    if (!node) return node;
-
-    // The initial call to this function is an array of nodes
-    if (node.constructor === Array) {
-        let errors = [];
-
-        const fieldErrors = node.reduce((memo, currentNode) => {
-            const name = currentNode.ref.props.name;
-            const childResult = toErrors(currentNode, treeValues[name], treeErrors[name], form);
-
-            memo[name] = childResult.fieldErrors;
-            errors = errors.concat(childResult.errors);
-            return memo;
-        }, {});
-
-        return { fieldErrors, errors };
-    }
-
-    // We want to get errrors from the bottom up. To do this we start by always
-    // getting the errors for our children first. Once we have our childrens
-    // errors, we validate ourselves against our children. Lastly, we return the
-    // result of these checks
-
-    // These will be our return types:
-    // fieldErrors: Object | Array (depending on the type of node.refs) If
-    // node.refs doesn't exist it means we are a leaf and will have an array of
-    // strings
-    let fieldErrors;
-    // errors: Array (always)
-    let errors = [];
-
-    // Here we have children, we are not a leaf
-    if (node.refs) {
-        if (node.refs.constructor === Array) {
-            fieldErrors = node.refs.map((currentNode, i) => {
-                const childResult = toErrors(currentNode, treeValues[i], treeErrors[i], form);
-
-                errors = errors.concat(childResult.errors);
-                return childResult.fieldErrors;
-            });
-        } else {
-            // Iterate over each child. And add our child errors to our errors
-            fieldErrors = values(node.refs).reduce((memo, currentNode) => {
-                const name = currentNode.ref.props.name;
-                const childResult = toErrors(currentNode, treeValues[name], treeErrors[name], form);
-
-                memo[name] = childResult.fieldErrors;
-                errors = errors.concat(childResult.errors);
-                return memo;
-            }, {});
-        }
-    }
-
-    // Get our current node's validators. They can be on props or this
-    const validators = [].concat(
-        node.ref.props.validators || [],
-        node.ref.validators || []
-    );
-    // Validate the current node
-    const validationErrors = validators
-                                .map(validator => validator.call(
-                                    node.ref,
-                                    treeValues,
-                                    form.fieldValues,
-                                    form.fieldErrors,
-                                    treeErrors
-                                ))
-                                .filter(identity);
-
-    errors = errors.concat(validationErrors);
-
-
-    // Our field errors will either be our childrens fieldErrors (if we have
-    // children) or our validation errors
-    fieldErrors = fieldErrors || validationErrors;
-
-    return { fieldErrors, errors };
-}
-
 
 export default React.createClass({
     displayName: 'Form',
@@ -184,15 +62,24 @@ export default React.createClass({
     },
 
     serialize() {
-        let iteration = 0;
-        // TODO: Lolololol, we need to count how many nodes there are
-        // and use that as our upper bound
-        const refLength = 20;
-
-        // Build the object of inputs
-        const nodes = values(this.refs || {})
+        // Build our list of children
+        const refs = values(this.refs || {})
                 .filter(ref => (ref.getInputs || ref.getValue))
-                .map(ref => ref.getInputs ? ref.getInputs() : { ref });
+                .map(ref => ref.getInputs ? ref.getInputs() : { ref })
+                .map(tree)
+                .reduce((memo, node) => {
+                    memo[node.ref.props.name] = node;
+                    return memo;
+                }, {});
+
+        // Make our tree which we will use for serialization and validation
+        const formTree = tree({ ref: this, refs });
+
+        // Calculate how many times we should serialize in the case of
+        // cycles when addValidationFieldErrors is true. We do this by
+        // counting how many nodes are in our tree
+        const refLength = formTree.map(() => 1).reduce((a,b) => a+b, 0);
+        let iteration = 0;
 
         let form = getBlankForm();
         let oldForm = getBlankForm();
@@ -201,17 +88,35 @@ export default React.createClass({
             // Keep a copy of the previous iteration of the form so we can
             // detect if the form is stable to exit early
             oldForm = Object.assign({}, form);
-            form.fieldValues = nodeToValues(nodes);
-            const { fieldErrors, errors } = toErrors(
-                nodes,
-                form.fieldValues,
-                form.fieldErrors,
-                form
-            );
 
-            form.fieldErrors = fieldErrors;
-            form.errors = errors;
+            // Gather our fieldValues from our tree
+            form.fieldValues = treeValue(formTree);
+
+            // Make a new temporary error tree. We will use this tree to
+            // generate a nested object (fieldErrors) and again to reduce it
+            // into an array (errors)
+            const formTreeErrors = formTree
+                .extend(tree => {
+                    const validators = getValidators(tree.ref);
+                    const value = tree.ref.getValue ? tree.ref.getValue() : treeValue(tree);
+                    const fieldValues = form.fieldValues;
+                    const fieldErrors = this.props.addValidationFieldErrors ? oldForm.fieldErrors : null;
+
+                    return validators.map(fn => fn(value, fieldValues, fieldErrors));
+                });
+
+            form.fieldErrors = formTreeErrors.extract()
+            form.errors = formTreeErrors
+                            .reduce((acc, val) => {
+                                return acc.concat(val);
+                            }, []);
+
             iteration++;
+
+        // If we don't need fieldErrors in our validators, we only need to
+        // execute this do..while once. We need to loop because we don't have
+        // explicit dependencies. We fake dependencies by making
+        // an eventually stable tree.
         } while(
             this.props.circular &&
             iteration < refLength &&
@@ -219,15 +124,7 @@ export default React.createClass({
         );
 
         // Update valid here so our formValidators can make use of it
-        form.valid = !form.errors.length;
-
-        const formValidators = [].concat(
-            (this.props.validators || []),
-            (this.validators || [])
-        );
-        const formErrors = formValidators.map(fn => fn(form)).filter(e => e != undefined);
-
-        form.errors = uniq(form.errors.concat(formErrors));
+        form.errors = uniq(form.errors.filter(identity));
         form.valid = !form.errors.length;
 
         return form;

--- a/src/form.js
+++ b/src/form.js
@@ -15,7 +15,7 @@ export const getBlankForm =function getBlankForm() {
 };
 
 const treeValue = function treeValue(tree) {
-    return tree.map(ref => ref.getValue && ref.getValue()).extract();
+    return tree.map(value => value.getValue && value.getValue()).extract();
 };
 
 const getValidators = function getValidators(ref) {
@@ -66,14 +66,14 @@ export default React.createClass({
         const refs = values(this.refs || {})
                 .filter(ref => (ref.getInputs || ref.getValue))
                 .map(ref => ref.getInputs ? ref.getInputs() : { ref })
-                .map(tree)
+                .map(x => tree(x.ref, x.refs))
                 .reduce((memo, node) => {
-                    memo[node.ref.props.name] = node;
+                    memo[node.value.props.name] = node;
                     return memo;
                 }, {});
 
         // Make our tree which we will use for serialization and validation
-        const formTree = tree({ ref: this, refs });
+        const formTree = tree(this, refs);
 
         // Calculate how many times we should serialize in the case of
         // cycles when addValidationFieldErrors is true. We do this by
@@ -97,8 +97,8 @@ export default React.createClass({
             // into an array (errors)
             const formTreeErrors = formTree
                 .extend(tree => {
-                    const validators = getValidators(tree.ref);
-                    const value = tree.ref.getValue ? tree.ref.getValue() : treeValue(tree);
+                    const validators = getValidators(tree.value);
+                    const value = tree.value.getValue ? tree.value.getValue() : treeValue(tree);
                     const fieldValues = form.fieldValues;
                     const fieldErrors = this.props.addValidationFieldErrors ? oldForm.fieldErrors : null;
 

--- a/src/helpers/tree.js
+++ b/src/helpers/tree.js
@@ -1,0 +1,48 @@
+/*eslint func-style:0*/
+import mapObj from './mapObj';
+import values from './values';
+
+function map(fn) {
+    return function (data) {
+        if (!data) return;
+
+        if (data.map) return data.map(fn);
+
+        if (typeof data === 'object') {
+            return mapObj(fn, data);
+        }
+    }
+}
+
+function extract(obj) {
+    return obj.extract();
+}
+
+export default function tree({ ref, refs }) {
+    return {
+        // The children of the tree
+        refs,
+
+        // The value which we will map over
+        ref,
+
+        // Map over each ref in the tree
+        map: fn => tree({ ref: fn(ref), refs: map(map(fn))(refs) }),
+
+        // Get the value of the (sub)tree as an object / array
+        extract: () => refs ? map(extract)(refs) : ref,
+
+        // Create a new tree by maping over the full tree
+        extend: (f) => tree({
+            ref: f(tree({ ref, refs })),
+            refs: map(x => x.extend(f))(refs)
+        }),
+        
+        // Boil down the tree into one value, node by node
+        reduce: (fn, acc) => {
+            return values(refs).reduce((memo, node) => {
+                return node.reduce(fn, memo);
+            }, fn(acc, ref));
+        }
+    };
+}

--- a/src/helpers/tree.js
+++ b/src/helpers/tree.js
@@ -27,34 +27,34 @@ function map(fn) {
     }
 }
 
-export default function tree({ ref, refs }) {
+export default function tree(value, children) {
     return {
         // The children of the tree
-        refs,
+        value,
 
         // The value which we will map over
-        ref,
+        children,
 
-        // Map over each ref in the tree reciving and modifying ref
-        map: fn => tree({ ref: fn(ref), refs: map(map(fn))(refs) }),
+        // Map over each value in the tree reciving and modifying value
+        map: fn => tree(fn(value), map(map(fn))(children)),
 
         // Get the value of the (sub)tree as an object / array
-        extract: () => refs ? map(x => x.extract())(refs) : ref,
+        extract: () => children ? map(x => x.extract())(children) : value,
 
         // Create a new tree by maping over the full tree
-        // f takes in the full tree value. Whatever f returns gets
+        // fn takes in the full tree value. Whatever fn returns gets
         // stored within the value of the node. Recuses down the tree
-        extend: (f) => tree({
-            ref: f(tree({ ref, refs })),
-            refs: map(x => x.extend(f))(refs)
-        }),
+        extend: (fn) => tree(
+            fn(tree(value, children)),
+            map(x => x.extend(fn))(children)
+        ),
 
         // Boil down the tree into one value, node by node
-        // fn recives the ref value for each node
+        // fn recives the value value for each node
         reduce: (fn, acc) => {
-            return values(refs).reduce((memo, node) => {
+            return values(children).reduce((memo, node) => {
                 return node.reduce(fn, memo);
-            }, fn(acc, ref));
+            }, fn(acc, value));
         }
     };
 }

--- a/src/helpers/tree.js
+++ b/src/helpers/tree.js
@@ -2,6 +2,19 @@
 import mapObj from './mapObj';
 import values from './values';
 
+/**
+ * map
+ *
+ * Not your traditional map which is probably bad. This version is a noop when
+ * its data is null. Defaults to implemented map and also allows mapping over
+ * objects
+ *
+ * map :: (a -> b) -> [a] | {a} -> [a] | {b}
+ *
+ * @param {Function} fn Callback that transforms a value
+ * @param {a|Array|Object} data the information to map over
+ * @return {a|Array|Object} Returns whatever the data value is transformed
+ */
 function map(fn) {
     return function (data) {
         if (!data) return;
@@ -14,10 +27,6 @@ function map(fn) {
     }
 }
 
-function extract(obj) {
-    return obj.extract();
-}
-
 export default function tree({ ref, refs }) {
     return {
         // The children of the tree
@@ -26,19 +35,22 @@ export default function tree({ ref, refs }) {
         // The value which we will map over
         ref,
 
-        // Map over each ref in the tree
+        // Map over each ref in the tree reciving and modifying ref
         map: fn => tree({ ref: fn(ref), refs: map(map(fn))(refs) }),
 
         // Get the value of the (sub)tree as an object / array
-        extract: () => refs ? map(extract)(refs) : ref,
+        extract: () => refs ? map(x => x.extract())(refs) : ref,
 
         // Create a new tree by maping over the full tree
+        // f takes in the full tree value. Whatever f returns gets
+        // stored within the value of the node. Recuses down the tree
         extend: (f) => tree({
             ref: f(tree({ ref, refs })),
             refs: map(x => x.extend(f))(refs)
         }),
-        
+
         // Boil down the tree into one value, node by node
+        // fn recives the ref value for each node
         reduce: (fn, acc) => {
             return values(refs).reduce((memo, node) => {
                 return node.reduce(fn, memo);


### PR DESCRIPTION
## Things changed
- Our serialize is simpler(?)
- We renamed the prop `circular` on form to `addValidationFieldErrors`. Now by default validators only get `value, fieldValues`. If you want access to `fieldErrors` in your validators you need to set that flag to true on your form. When it is true, we serialize the form until it is consistent. 
## General approach:

Here we introduce a `tree` type which has a two properties (`ref` which is really value, and `refs` which is really children). With these types we implement a few methods like map and reduce. Since these methods know about the type they are in, they handle the recursion for us. This means we can map over our data structure just like we would map over an array and not worry about the details. 

More interesting is the use of `extend` and `extract`. Together, these functions form a comonad, a scary way to say that some values of the tree are dependent on the values around it. In this case, when generating errors, inputs can depend on other inputs near them in the tree. [Here](http://joneshf.github.io/programming/2015/12/31/Comonads-Monoids-and-Trees.html#comonad) is what inspired me to go down this route. 
## Room for improvement:
- The logic to convert children to tree nodes (found [here](https://github.com/willowtreeapps/react-formable/compare/refactor-serialize?expand=1#diff-62acef2590804164cb77b4b5aced00ebR66) and [here](https://github.com/willowtreeapps/react-formable/compare/refactor-serialize?expand=1#diff-8389c7b33442fb3f5cab4ca39fd8be63R23) could / should be abstracted away.
- We are using plain javascript objects to represent our type [here](https://github.com/willowtreeapps/react-formable/compare/refactor-serialize?expand=1#diff-c749ff30aede17a22cf83e1cb3bf7dadR21). This means that the methods attached to the tree type are created for each node. If we really care we can make a proper class and attach them to the prototype
- The values `ref` and `refs` from `getInputs` as well as the constructor of the tree could be improved / renamed. `value` and `children` would be more explicit.
- Break out the functions in the tree file
- Tests...
