### PR TITLE
Stateless Component Bugfix

### DIFF
--- a/src/__tests__/form-test.js
+++ b/src/__tests__/form-test.js
@@ -213,4 +213,19 @@ describe('Form', () => {
             errors: ['kaboom']
         });
     });
+
+    it('it checks for the existance of ref before using it in serialize', () => {
+        const Icon = props => <i {...props} />;
+
+        const form = TestUtils.renderIntoDocument(
+            <Form>
+                <Input name="firstname" type="text" />
+                <Icon name="icon" />
+            </Form>
+        );
+
+        expect(form.serialize().fieldValues).toEqual({
+            firstname: ''
+        });
+    });
 });

--- a/src/form.js
+++ b/src/form.js
@@ -64,7 +64,7 @@ export default React.createClass({
     serialize() {
         // Build our list of children
         const refs = values(this.refs || {})
-                .filter(ref => (ref.getInputs || ref.getValue))
+                .filter(ref => ref && (ref.getInputs || ref.getValue))
                 .map(ref => ref.getInputs ? ref.getInputs() : { ref })
                 .map(x => tree(x.ref, x.refs))
                 .reduce((memo, node) => {


### PR DESCRIPTION
Here is the scenario I was facing: You have a non-input / fieldset stateless component with a `name` prop rendered in your form. For the most part we handle this gracefully. However when we serialize the form we don't check for the existance of `ref` (which stateless components don't have). 

This adds a test and validates that we won't crash when serializing stateless components. 
