### PR TITLE
Fixes issue #90

### DIFF
--- a/src/inputs/input.tsx
+++ b/src/inputs/input.tsx
@@ -42,7 +42,13 @@ export default class Input extends React.Component<IInputProps, {}> {
     }
 
     public getValue(): AnyType {
-        return this.refs.input.value;
+        switch(this.refs.input.type) {
+            case 'checkbox':
+            case 'radio':
+                return this.refs.input.checked;
+            default:
+                return this.refs.input.value;
+        }
     }
 
     private onChange(e: AnyType): void {


### PR DESCRIPTION
With this, I check if the input is a `radio` or `checkbox` and if so, return `checked` instead of `value`.
