### PR TITLE
Delete errors and warnings

### DIFF
--- a/src/__tests__/fieldset-test.tsx
+++ b/src/__tests__/fieldset-test.tsx
@@ -4,26 +4,12 @@ jest.unmock('../fieldset');
 jest.unmock('../inputs/input');
 
 import * as React from 'react';
-const ReactDOM = require('react-dom');
 const TestUtils = require('react-addons-test-utils');
 
 const Fieldset = require('../fieldset').default;
 const Input = require('../inputs/input').default;
 
 describe('Fieldset', () => {
-    it('renders div with name of the fieldset', () => {
-        let fieldset: any = TestUtils.renderIntoDocument(
-            <Fieldset name="pet">
-                <label> Pet Name: <Input name="name" type="text" /> </label>
-                <label> Pet Type: <Input name="type" type="text" /> </label>
-            </Fieldset>
-        );
-
-        const fieldsetNode = ReactDOM.findDOMNode(fieldset);
-
-        expect(fieldsetNode.getAttribute('name')).toBe('pet');
-    });
-
     it('can get inputs', () => {
         let fieldset: any = TestUtils.renderIntoDocument(
             <Fieldset name="pet">

--- a/src/__tests__/form-test.tsx
+++ b/src/__tests__/form-test.tsx
@@ -248,7 +248,7 @@ describe('Form', () => {
     });
 
     it('it checks for the existance of ref before using it in serialize', () => {
-        const Icon = props => <i {...props} />;
+        const Icon = props => <i />;
 
         const form: any = TestUtils.renderIntoDocument(
             <Form>

--- a/src/errors.tsx
+++ b/src/errors.tsx
@@ -38,9 +38,7 @@ export default class Fieldlist extends React.Component<IErrorsProps, {}> {
         const allErrors = [].concat(scoped ? fieldErrors : errors)
                             .concat(additionalErrors);
 
-        if (!allErrors.length) { return <span />; }
-
-        const className = `${this.props.className} errors`;
+        const className = `${this.props.className} ${allErrors.length ? 'has-errors' : ''} errors`;
 
         return <ul className={className}>
             {allErrors.map((error, i) =>

--- a/src/errors.tsx
+++ b/src/errors.tsx
@@ -6,8 +6,8 @@ import flatten from './helpers/flatten';
 import values from './helpers/values';
 
 interface IErrorsDefaultProps {
-    errors?: string[];
-    additionalErrors?: string[];
+    errors?: any[];
+    additionalErrors?: any[];
     fieldErrors?: any;
     scoped?: boolean;
     renderError?: (error: any) => void;

--- a/src/errors.tsx
+++ b/src/errors.tsx
@@ -10,7 +10,7 @@ interface IErrorsDefaultProps {
     additionalErrors?: any[];
     fieldErrors?: any;
     scoped?: boolean;
-    renderError?: (error: any) => void;
+    renderError?: (error: any) => React.ReactElement<{}>;
     className?: string;
 }
 

--- a/src/fieldlist.tsx
+++ b/src/fieldlist.tsx
@@ -5,6 +5,7 @@ import values from './helpers/values';
 import Fieldset from './fieldset';
 import AnyObject from './types/anyObject';
 import { TArray } from './helpers/tree';
+import omit from './helpers/omit';
 const warning = require('warning');
 
 interface IFieldlistProps {
@@ -37,10 +38,11 @@ export default class Fieldlist extends React.Component<IFieldlistProps, {}> {
         const errors = this.props.errors || [];
         const fieldErrors = this.props.fieldErrors || [];
 
-        let props = this.props;
-        delete props.errors;
-        delete props.fieldErrors;
-        delete props.name;
+        const props = omit([
+            'errors',
+            'fieldErrors',
+            'name'
+        ], this.props);
 
         // Overwrite errors and fieldErrors passed in here as fieldset expects
         // different errors than fieldlist. There is no need to pass them down

--- a/src/fieldset.tsx
+++ b/src/fieldset.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import cloneChildren, { createErrorsRule, createFormableRule } from './helpers/cloneChildren';
 import values from './helpers/values';
 import { TObject, TLeaf } from './helpers/tree';
+import omit from './helpers/omit';
 import AnyObject from './types/anyObject';
 const warning = require('warning');
 
@@ -51,10 +52,11 @@ export default class Fieldset extends React.Component<IFieldsetProps, {}> {
 
         const child: any = this.props.children;
 
-        let props = this.props;
-        delete props.errors;
-        delete props.fieldErrors;
-        delete props.name;
+        const props = omit([
+            'errors',
+            'fieldErrors',
+            'name'
+        ], this.props);
 
         return <div {...props}>
             {cloneChildren([errorsRule, formableRule], child)}

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -7,6 +7,7 @@ import cloneChildren, { createErrorsRule, createFormableRule } from './helpers/c
 import { TObject, TLeaf } from './helpers/tree';
 import promiseEvery from './helpers/promiseEvery';
 import identity from './helpers/identity';
+import omit from './helpers/omit';
 
 export interface IValidation {
     fieldErrors: any;
@@ -222,13 +223,14 @@ export default class Formable<T> extends React.Component<IFormableProps<T>, IFor
         );
         const children: any = this.props.children;
 
-        let props = this.props;
-        delete props.addValidationFieldErrors;
-        delete props.onChange;
-        delete props.showErrorsOnSubmit;
-        delete props.showErrorsOnChange;
-        delete props.delayOnSubmit;
-        delete props.validators;
+        const props = omit([
+            'addValidationFieldErrors',
+            'onChange',
+            'showErrorsOnSubmit',
+            'showErrorsOnChange',
+            'delayOnSubmit',
+            'validators'
+        ], this.props);
 
         return <form {...props}
                     ref="form"

--- a/src/inputs/input.tsx
+++ b/src/inputs/input.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import omit from '../helpers/omit';
 
 interface IInputDefaultProps {
     onChange?: () => void;
@@ -61,11 +62,13 @@ export default class Input extends React.Component<IInputProps, {}> {
         const hasError = this.props.fieldErrors && this.props.fieldErrors.length;
         const className = `${this.props.className} ${hasError ? 'error' : ''}`;
 
-        let props = this.props;
-        delete props.name;
-        delete props.fieldErrors;
-        delete props.validateOnBlur;
-        delete props.validators;
+        const props = omit([
+            'name',
+            'errors',
+            'fieldErrors',
+            'validateOnBlur',
+            'validators'
+        ], this.props);
 
         return <input {...props}
                       className={className}

--- a/src/inputs/input.tsx
+++ b/src/inputs/input.tsx
@@ -63,7 +63,6 @@ export default class Input extends React.Component<IInputProps, {}> {
         const className = `${this.props.className} ${hasError ? 'error' : ''}`;
 
         const props = omit([
-            'name',
             'errors',
             'fieldErrors',
             'validateOnBlur',


### PR DESCRIPTION
Fixes #94, #93, #95. 

While I was in the `<Errors />` component, I loosed up the interface from only accepting `string` to `any` for `errors` and `additionalErrors`. This lets users drop anything they want into this component and use `renderError?: (error: any) => React.ReactElement<{}>;` to render them appropriately. 

Yea, this probably should have been two PRs 😁 