### PR TITLE
Adds warning for badly named components

### DIFF
--- a/src/helpers/cloneChildren.ts
+++ b/src/helpers/cloneChildren.ts
@@ -89,7 +89,16 @@ function getFormableComponentProperties(errors, fieldErrors, onSubmit, onChange)
 export function createFormableRule(errors = [], fieldErrors = {},
     onSubmit = identity, onChange = identity) {
     return {
-        predicate: child => child.props && child.props.name,
+        predicate: child => {
+            const hasName = child.props && child.props.name;
+            const hasType = child.type && child.type.prototype;
+            const hasGetValue = hasType && child.type.prototype.getValue;
+            const hasGetInputs = hasType && child.type.prototype.getInputs;
+
+            warning(!(hasName && hasType && !(hasGetValue || hasGetInputs)), `You have an improperly named component: "${child.props.name}". Please see https://github.com/willowtreeapps/react-formable/issues/92`);
+
+            return hasName && (hasGetValue || hasGetInputs);
+        },
         clone: (child, childNames) => {
             return React.cloneElement(
                 child,

--- a/src/helpers/cloneChildren.ts
+++ b/src/helpers/cloneChildren.ts
@@ -86,8 +86,12 @@ function getFormableComponentProperties(errors, fieldErrors, onSubmit, onChange)
 /*
  * Standard cloning rule for something react-formable
  */
-export function createFormableRule(errors = [], fieldErrors = {},
-    onSubmit = identity, onChange = identity) {
+export function createFormableRule(
+    errors = [],
+    fieldErrors = {},
+    onSubmit = identity,
+    onChange = identity
+) {
     return {
         predicate: child => {
             const hasName = child.props && child.props.name;


### PR DESCRIPTION
Fixes issue #92 

I dare say we are reaching too much into react internals here. Here is the challenge. We only want to attach `ref`s to valid formable inputs (a `React.Component` or similar component with a `getValue` function). The challenge is you normally sniff out that function via the `ref` and its instance. However when we are cloning these inputs, we don't have an instance yet. To get around this we inspect the prototype of the type of the component. 