### PR TITLE
onSubmit delay

### DIFF
--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -22,12 +22,12 @@ export interface Props {
     showErrorsOnSubmit: boolean,
     onChange: (fieldValues: any, validation?: any) => void,
     onSubmit: (fieldValues: any, validation: any) => void,
+    onSubmitSuccess: (fieldValues: any) => void,
     fieldErrorsToProps: (fieldErrors: any[], props: any) => any,
     debounceValidation: number,
     configureForm: ConfigureForm,
     removeValidators: boolean,
-    removePropName: boolean,
-    callSubmitWithInvalidData: boolean
+    removePropName: boolean
 }
 
 export interface State {
@@ -61,7 +61,6 @@ class _Form extends React.Component<Props, State> {
         removePropName: false,
         fieldErrorsToProps: defaultFieldErrorsToProps,
         removeValidators: true,
-        callSubmitWithInvalidData: true,
         configureForm: (type, props) =>
             type === 'input' && (props.type === 'radio' || props.type === 'checkbox')
                 ? defaultConfigureCheckbox
@@ -161,12 +160,11 @@ class _Form extends React.Component<Props, State> {
             if (this.props.showErrorsOnSubmit)
                 this.setState({ errors: validation.errors })
 
-            const shouldCallOnSubmit =
-                this.props.callSubmitWithInvalidData ||
-                (!this.props.callSubmitWithInvalidData && validation.valid)
-
-            if (this.props.onSubmit && shouldCallOnSubmit)
+            if (this.props.onSubmit)
                 this.props.onSubmit(fieldValues, validation)
+
+            if (this.props.onSubmitSuccess && validation.valid)
+                this.props.onSubmitSuccess(fieldValues)
         })
 
         // Immediately execute submit validation

--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -26,7 +26,8 @@ export interface Props {
     debounceValidation: number,
     configureForm: ConfigureForm,
     removeValidators: boolean,
-    removePropName: boolean
+    removePropName: boolean,
+    callSubmitWithInvalidData: boolean
 }
 
 export interface State {
@@ -60,6 +61,7 @@ class _Form extends React.Component<Props, State> {
         removePropName: false,
         fieldErrorsToProps: defaultFieldErrorsToProps,
         removeValidators: true,
+        callSubmitWithInvalidData: true,
         configureForm: (type, props) =>
             type === 'input' && (props.type === 'radio' || props.type === 'checkbox')
                 ? defaultConfigureCheckbox
@@ -159,7 +161,11 @@ class _Form extends React.Component<Props, State> {
             if (this.props.showErrorsOnSubmit)
                 this.setState({ errors: validation.errors })
 
-            if (this.props.onSubmit)
+            const shouldCallOnSubmit =
+                this.props.callSubmitWithInvalidData ||
+                (!this.props.callSubmitWithInvalidData && validation.valid)
+
+            if (this.props.onSubmit && shouldCallOnSubmit)
                 this.props.onSubmit(fieldValues, validation)
         })
 

--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -22,12 +22,16 @@ export interface Props {
     showErrorsOnSubmit: boolean,
     onChange: (fieldValues: any, validation?: any) => void,
     onSubmit: (fieldValues: any, validation: any) => void,
-    onSubmitSuccess: (fieldValues: any) => void,
     fieldErrorsToProps: (fieldErrors: any[], props: any) => any,
     debounceValidation: number,
     configureForm: ConfigureForm,
     removeValidators: boolean,
-    removePropName: boolean
+    removePropName: boolean,
+    // noValidate
+    // true -> onSubmit will get call regardless of validation
+    // false -> (DEFAULT) onSubmit will get called only when form is valid
+    noValidate: boolean
+
 }
 
 export interface State {
@@ -61,6 +65,7 @@ class _Form extends React.Component<Props, State> {
         removePropName: false,
         fieldErrorsToProps: defaultFieldErrorsToProps,
         removeValidators: true,
+        noValidate: false,
         configureForm: (type, props) =>
             type === 'input' && (props.type === 'radio' || props.type === 'checkbox')
                 ? defaultConfigureCheckbox
@@ -160,11 +165,8 @@ class _Form extends React.Component<Props, State> {
             if (this.props.showErrorsOnSubmit)
                 this.setState({ errors: validation.errors })
 
-            if (this.props.onSubmit)
+            if (this.props.onSubmit && (validation.valid || this.props.noValidate))
                 this.props.onSubmit(fieldValues, validation)
-
-            if (this.props.onSubmitSuccess && validation.valid)
-                this.props.onSubmitSuccess(fieldValues)
         })
 
         // Immediately execute submit validation


### PR DESCRIPTION
So it is debatable if `onSubmit` should be called with an invalid form. 90% of the time you can just have the default form validation take care of showing errors. In that case, it is just a distraction to call `onSubmit` with bad form data. 

This PR adds a prop to change how this works. Setting this prop to `false` will cause the form not to call `onSubmit` with bad form data. 

Thoughts on prop name / other thoughts? 